### PR TITLE
Remove __dirname from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require(__dirname + '/lib/jjv.js');
+module.exports = require('./lib/jjv.js');


### PR DESCRIPTION
To make Browserify work, make the require relative (ie './') instead of explicit via __dirname.
