### PR TITLE
Expose resolveURI method as resolveRef(schema, $ref).

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -577,8 +577,7 @@
     },
 
     resolveRef: function (schema, $ref) {
-      refs = resolveURI(this, schema, $ref);
-      return refs[1]
+      return resolveURI(this, schema, $ref);
     },
 
     addType: function (name, func) {


### PR DESCRIPTION
This is a useful function for anyone wanting to use JJV as a
schema inspector. 

In my case, I'm working on a dynamic, JSON Schema driven form generator. I'm already using JJV to validate the provided schema against draft-04. I made this addition to easily resolve a $ref while traversing the schema.

Thoughts?
