### PR TITLE
Escape one backslash with other backslash.

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -186,6 +186,7 @@
         pattern=p[0];
         modifiers=p[1];
       }
+      pattern = pattern.replace(/\\/g, "\\");
       var regex = new RegExp(pattern, modifiers);
       return regex.test(v);
     },


### PR DESCRIPTION
Escape one backslash with other backslash.
When schema deserialized from json, one escape symbol works with next symbol, and not appeared in the result string (pattern)
This can fix problem
