### PR TITLE
Don't use window to access global object

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -694,5 +694,5 @@
   else if (typeof define === 'function' && define.amd)
     define(function () {return Environment;});
   else
-    window.jjv = Environment;
-})();
+    this.jjv = Environment;
+}).call(this);


### PR DESCRIPTION
In order to support contexts that don't use modules but aren't the browser.
