### PR TITLE
Allow user to override checkValidity

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -348,7 +348,7 @@
       if (!schema_stack)
         return {'$ref': schema.$ref};
       else
-        return checkValidity(env, schema_stack, object_stack, options);
+        return env.checkValidity(env, schema_stack, object_stack, options);
     }
 
     if (schema.hasOwnProperty('type')) {
@@ -369,7 +369,7 @@
 
     if (schema.hasOwnProperty('allOf')) {
       for (i = 0, len = schema.allOf.length; i < len; i++) {
-        objerr = checkValidity(env, schema_stack.concat(schema.allOf[i]), object_stack, options);
+        objerr = env.checkValidity(env, schema_stack.concat(schema.allOf[i]), object_stack, options);
         if (objerr)
           return objerr;
       }
@@ -379,7 +379,7 @@
       if (schema.hasOwnProperty('oneOf')) {
         minErrCount = Infinity;
         for (i = 0, len = schema.oneOf.length, count = 0; i < len; i++) {
-          objerr = checkValidity(env, schema_stack.concat(schema.oneOf[i]), object_stack, options);
+          objerr = env.checkValidity(env, schema_stack.concat(schema.oneOf[i]), object_stack, options);
           if (!objerr) {
             count = count + 1;
             if (count > 1)
@@ -403,7 +403,7 @@
         objerrs = null;
         minErrCount = Infinity;
         for (i = 0, len = schema.anyOf.length; i < len; i++) {
-          objerr = checkValidity(env, schema_stack.concat(schema.anyOf[i]), object_stack, options);
+          objerr = env.checkValidity(env, schema_stack.concat(schema.anyOf[i]), object_stack, options);
           if (!objerr) {
             objerrs = null;
             break;
@@ -421,7 +421,7 @@
       }
 
       if (schema.hasOwnProperty('not')) {
-        objerr = checkValidity(env, schema_stack.concat(schema.not), object_stack, options);
+        objerr = env.checkValidity(env, schema_stack.concat(schema.not), object_stack, options);
         if (!objerr)
           return {'not': true};
       }
@@ -430,7 +430,7 @@
         minErrCount = Infinity;
         for (i = 0, len = schema.oneOf.length, count = 0; i < len; i++) {
           new_stack = clone_stack(object_stack);
-          objerr = checkValidity(env, schema_stack.concat(schema.oneOf[i]), new_stack, options);
+          objerr = env.checkValidity(env, schema_stack.concat(schema.oneOf[i]), new_stack, options);
           if (!objerr) {
             count = count + 1;
             if (count > 1)
@@ -457,7 +457,7 @@
         minErrCount = Infinity;
         for (i = 0, len = schema.anyOf.length; i < len; i++) {
           new_stack = clone_stack(object_stack);
-          objerr = checkValidity(env, schema_stack.concat(schema.anyOf[i]), new_stack, options);
+          objerr = env.checkValidity(env, schema_stack.concat(schema.anyOf[i]), new_stack, options);
           if (!objerr) {
             copy_stack(new_stack, object_stack);
             objerrs = null;
@@ -477,7 +477,7 @@
 
       if (schema.hasOwnProperty('not')) {
         new_stack = clone_stack(object_stack);
-        objerr = checkValidity(env, schema_stack.concat(schema.not), new_stack, options);
+        objerr = env.checkValidity(env, schema_stack.concat(schema.not), new_stack, options);
         if (!objerr)
           return {'not': true};
       }
@@ -492,7 +492,7 @@
                 return {'dependencies': true};
               }
           } else {
-            objerr = checkValidity(env, schema_stack.concat(schema.dependencies[p]), object_stack, options);
+            objerr = env.checkValidity(env, schema_stack.concat(schema.dependencies[p]), object_stack, options);
             if (objerr)
               return objerr;
           }
@@ -522,7 +522,7 @@
           matched = false;
           if (hasProp && schema.properties.hasOwnProperty(props[i])) {
             matched = true;
-            objerr = checkValidity(env, schema_stack.concat(schema.properties[props[i]]), object_stack.concat({object: prop, key: props[i]}), options);
+            objerr = env.checkValidity(env, schema_stack.concat(schema.properties[props[i]]), object_stack.concat({object: prop, key: props[i]}), options);
             if (objerr !== null) {
               objerrs[props[i]] = objerr;
               malformed = true;
@@ -532,7 +532,7 @@
             for (p in schema.patternProperties)
               if (schema.patternProperties.hasOwnProperty(p) && props[i].match(p)) {
                 matched = true;
-                objerr = checkValidity(env, schema_stack.concat(schema.patternProperties[p]), object_stack.concat({object: prop, key: props[i]}), options);
+                objerr = env.checkValidity(env, schema_stack.concat(schema.patternProperties[p]), object_stack.concat({object: prop, key: props[i]}), options);
                 if (objerr !== null) {
                   objerrs[props[i]] = objerr;
                   malformed = true;
@@ -564,7 +564,7 @@
             }
           } else {
             for (i = 0, len = props.length; i < len; i++) {
-              objerr = checkValidity(env, schema_stack.concat(schema.additionalProperties), object_stack.concat({object: prop, key: props[i]}), options);
+              objerr = env.checkValidity(env, schema_stack.concat(schema.additionalProperties), object_stack.concat({object: prop, key: props[i]}), options);
               if (objerr !== null) {
                 objerrs[props[i]] = objerr;
                 malformed = true;
@@ -579,7 +579,7 @@
       if (schema.hasOwnProperty('items')) {
         if (Array.isArray(schema.items)) {
           for (i = 0, len = schema.items.length; i < len; i++) {
-            objerr = checkValidity(env, schema_stack.concat(schema.items[i]), object_stack.concat({object: prop, key: i}), options);
+            objerr = env.checkValidity(env, schema_stack.concat(schema.items[i]), object_stack.concat({object: prop, key: i}), options);
             if (objerr !== null) {
               objerrs[i] = objerr;
               malformed = true;
@@ -591,7 +591,7 @@
                 return {'additionalItems': true};
             } else {
               for (i = len, len = prop.length; i < len; i++) {
-                objerr = checkValidity(env, schema_stack.concat(schema.additionalItems), object_stack.concat({object: prop, key: i}), options);
+                objerr = env.checkValidity(env, schema_stack.concat(schema.additionalItems), object_stack.concat({object: prop, key: i}), options);
                 if (objerr !== null) {
                   objerrs[i] = objerr;
                   malformed = true;
@@ -601,7 +601,7 @@
           }
         } else {
           for (i = 0, len = prop.length; i < len; i++) {
-            objerr = checkValidity(env, schema_stack.concat(schema.items), object_stack.concat({object: prop, key: i}), options);
+            objerr = env.checkValidity(env, schema_stack.concat(schema.items), object_stack.concat({object: prop, key: i}), options);
             if (objerr !== null) {
               objerrs[i] = objerr;
               malformed = true;
@@ -611,7 +611,7 @@
       } else if (schema.hasOwnProperty('additionalItems')) {
         if (typeof schema.additionalItems !== 'boolean') {
           for (i = 0, len = prop.length; i < len; i++) {
-            objerr = checkValidity(env, schema_stack.concat(schema.additionalItems), object_stack.concat({object: prop, key: i}), options);
+            objerr = env.checkValidity(env, schema_stack.concat(schema.additionalItems), object_stack.concat({object: prop, key: i}), options);
             if (objerr !== null) {
               objerrs[i] = objerr;
               malformed = true;
@@ -665,6 +665,7 @@
   }
 
   Environment.prototype = {
+    checkValidity: checkValidity,
     validate: function (name, object, options) {
       var schema_stack = [name], errors = null, object_stack = [{object: {'__root__': object}, key: '__root__'}];
 
@@ -682,7 +683,7 @@
             options[p] = this.defaultOptions[p];
       }
 
-      errors = checkValidity(this, schema_stack, object_stack, options);
+      errors = this.checkValidity(this, schema_stack, object_stack, options);
 
       if (errors)
         return {validation: errors.hasOwnProperty('schema') ? errors.schema : errors};


### PR DESCRIPTION
What do you think about letting the user override checkValidity?

``` javascript
var env = jjv();

var checkValidity = env.checkValidity;

env.checkValidity = function(env, schema_stack, object_stack, options) {
  var result = checkValidity(env, schema_stack, object_stack, options);
  // do something interesting
  return result;
};

env.validate(schema, data);
```

This would make it a lot easier to write error formatting code. Right now I have to re-walk the JSON schema (along with the data object) if I want to get access to stuff like enum lists (and the invalid data).

Also, the current validation object doesn't give you enough information re-walk the JSON schema where the path includes stuff like anyOf (without re-validating the data).

Just for reference, I'm trying to get errors like the following:

``` json
{
  "code": "VALIDATION_ENUM_MISMATCH",
  "message": "Not a valid option (three), expects: one, two",
  "data": "three",
  "path": "$.str"
}
```

For something like

``` javascript
var schema = {
  type: 'object',
  properties: {
    str: { type: 'string', enum: ['one', 'two'] },
  }
};

var data = {
  str: 'three',
};
```
