### PR TITLE
Default values inserted by useDefault option must be cloned, not just assigned

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -547,7 +547,7 @@
       if (options.useDefault && hasProp && !malformed) {
         for (p in schema.properties)
           if (schema.properties.hasOwnProperty(p) && !prop.hasOwnProperty(p) && schema.properties[p].hasOwnProperty('default'))
-            prop[p] = schema.properties[p]['default'];
+            prop[p] = clone(schema.properties[p]['default']);
       }
 
       if (options.removeAdditional && hasProp && schema.additionalProperties !== true && typeof schema.additionalProperties !== 'object') {

--- a/test/test-mini.js
+++ b/test/test-mini.js
@@ -307,4 +307,31 @@ describe("basic functinal test", function () {
     };
     expect(jjv.validate(selfReferentialSchema, manifest)).to.be.null;
   });
+
+  describe("useDefault", function() {
+    it("should clone default values", function() {
+      var defaults_schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "prop": {
+              "type": "array",
+              "default": []
+            }
+          }
+        }
+      };
+      var defaults_object = [
+        {},
+        {}
+      ];
+      expect(jjv.validate(defaults_schema, defaults_object, {useDefault: true})).to.be.null;
+      expect(defaults_object[0].prop).to.deep.equal([]);
+      expect(defaults_object[1].prop).to.deep.equal([]);
+      defaults_object[0].prop.push(5);
+      expect(defaults_object[0].prop).to.deep.equal([5]);
+      expect(defaults_object[1].prop).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
The useDefault option has a bug that surfaces when default values are of mutable types (object, array) and the same sub-schema applies default values to multiple sub-objects of the object being validated (and possibly also when subsequent validations are done with the same Environment, though I didn’t check that): Because the default value is just assigned to the property, all properties end up with a reference to the same object, and when that object is later modified via one property, all the other properties get the modified object as well. The desired behavior (in my opinion) is that the default-assigned properties should be independent. For that, the values must be cloned before assignment.

These commits add a unit test and a fix for this.