### PR TITLE
Clone function fails to clone objects with hasOwnProperty

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -547,7 +547,7 @@
       if (options.useDefault && hasProp && !malformed) {
         for (p in schema.properties)
           if (schema.properties.hasOwnProperty(p) && !prop.hasOwnProperty(p) && schema.properties[p].hasOwnProperty('default'))
-            prop[p] = schema.properties[p]['default'];
+            prop[p] = clone(schema.properties[p]['default']);
       }
 
       if (options.removeAdditional && hasProp && schema.additionalProperties !== true && typeof schema.additionalProperties !== 'object') {

--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -38,9 +38,10 @@
       // Handle Object
       if (obj instanceof Object) {
           copy = {};
+          var hasOwnProperty = copy.hasOwnProperty;
 //           copy = Object.create(Object.getPrototypeOf(obj));
           for (var attr in obj) {
-              if (obj.hasOwnProperty(attr))
+              if (hasOwnProperty.call(obj, attr))
                 copy[attr] = clone(obj[attr]);
           }
           return copy;

--- a/test/test-mini.js
+++ b/test/test-mini.js
@@ -334,4 +334,23 @@ describe("basic functinal test", function () {
       expect(defaults_object[1].prop).to.deep.equal([]);
     });
   });
+
+  describe("clone function", function() {
+    it("should handle objects with a hasOwnProperty property", function() {
+      // suppress JSHint warning "'hasOwnProperty' is a really bad name" - we're purposely using really bad names here!
+      /* jshint -W001 */
+      var defaults_schema = {
+        "type": "object",
+        "properties": {
+          "prop": {
+            "type": "object",
+            "default": {"hasOwnProperty": "yes"}
+          }
+        }
+      };
+      var defaults_object = {};
+      expect(jjv.validate(defaults_schema, defaults_object, {useDefault: true})).to.be.null;
+      expect(defaults_object.prop).to.deep.equal({"hasOwnProperty": "yes"});
+    });
+  });
 });

--- a/test/test-mini.js
+++ b/test/test-mini.js
@@ -307,4 +307,31 @@ describe("basic functinal test", function () {
     };
     expect(jjv.validate(selfReferentialSchema, manifest)).to.be.null;
   });
+
+  describe("useDefault", function() {
+    it("should clone default values", function() {
+      var defaults_schema = {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "prop": {
+              "type": "array",
+              "default": []
+            }
+          }
+        }
+      };
+      var defaults_object = [
+        {},
+        {}
+      ];
+      expect(jjv.validate(defaults_schema, defaults_object, {useDefault: true})).to.be.null;
+      expect(defaults_object[0].prop).to.deep.equal([]);
+      expect(defaults_object[1].prop).to.deep.equal([]);
+      defaults_object[0].prop.push(5);
+      expect(defaults_object[0].prop).to.deep.equal([5]);
+      expect(defaults_object[1].prop).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
My previous PR #51 uncovered a small bug in the internal clone function of JJV: it currently fails to clone objects containing a property named “hasOwnProperty” (with a value different from the expected function).

The last two commits add a unit test and a fix for this.

I didn’t study in detail if this could have led to user-visible errors up to now, but it can with #51. This is also the reason why the two new commits are based on the two from there, as this is the misbehavior that the unit test tests.