### PR TITLE
Fix schema validation with OneOf or AnyOf 

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -61,7 +61,21 @@
 
   var copy_stack = function (new_stack, old_stack) {
     var stack_last = new_stack.length-1, key = new_stack[stack_last].key;
-    old_stack[stack_last].object[key] = new_stack[stack_last].object[key];
+
+    if (stack_last !== 0) {
+      old_stack[stack_last].object[key] = new_stack[stack_last].object[key];
+    } else {
+
+      Object.keys(new_stack[stack_last].object[key]).forEach(function(k) {
+        old_stack[stack_last].object[key][k] = new_stack[stack_last].object[key][k];
+      });
+
+      Object.keys(old_stack[stack_last].object[key]).forEach(function(k) {
+        if (!new_stack[stack_last].object[key].hasOwnProperty(k)) {
+          delete old_stack[stack_last].object[key][k];
+        }
+      });
+    }
   };
 
   var handled = {

--- a/test/fixtures/oneOf.json
+++ b/test/fixtures/oneOf.json
@@ -64,5 +64,81 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "oneOf, strip other",
+        "schema": {
+            "definition": {
+                "one": {
+                    "title": "schema 1",
+                    "properties": {
+                        "tool" : {"enum": ["set"] },
+                        "field": { "type": "string", "default": "field1"},
+                        "s1" : { "type": "string", "default": "on1"}
+                    },
+                    "required": ["tool"]
+                },
+                "two": {
+                    "title": "schema 2",
+                    "properties": {
+                        "tool" : {"enum": ["set 2"] },
+                        "s2" : { "type": "string", "default": "on2"}
+                    },
+                    "required": ["tool"]
+                 }
+             },
+             "oneOf": [{"$ref": "#/definition/one"}, {"$ref": "#/definition/two"}]
+        },
+        "tests": [
+            {
+                "description": "oneOf valid: get tool 'set', defaults 'field1' & 'on1', strip other",
+                "data": {
+                    "tool": "set",
+                    "other": "remove"
+                },
+                "valid": true,
+		"result": {
+			"tool": "set",
+			"field": "field1",
+			"s1": "on1"
+		},
+		"validateOptions": {"useDefault": true, "removeAdditional": true, "checkRequired": true}
+            }, {
+                "description": "oneOf valid, get set, field met and strip other",
+                "data": {
+                    "tool": "set",
+                    "field": "met",
+                    "other": "remove"
+                },
+                "valid": true,
+		"result": {
+			"tool": "set",
+			"field": "met",
+			"s1": "on1"
+		},
+		"validateOptions": {"useDefault": true, "removeAdditional": true, "checkRequired": true}
+            }, {
+                "description": "oneOf valid, get set 2 and strip other",
+                "data": {
+                    "tool": "set 2",
+                    "other": "remove"
+                },
+                "valid": true,
+		"result": {
+			"tool": "set 2",
+			"s2": "on2"
+		},
+		"validateOptions": {"useDefault": true, "removeAdditional": true, "checkRequired": true}
+            }, {
+                "description": "oneOf invalid due to tool",
+                "data": {
+                    "tool": "unknown",
+                    "other": "remove"
+                },
+                "valid": false,
+		"validateOptions": {"useDefault": true, "removeAdditional": true, "checkRequired": true}
+            }
+        ]
     }
+
 ]

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -17,15 +17,20 @@ env.addSchema('http://localhost:1234/subSchemas.json', {
                 "integer": { "type": "integer" },
                 "refToInteger": { "$ref": "#/integer" }
 });
-              
+
 function runTest(i, j, k) {
   var schema = tests[i][j].schema;
   var test = tests[i][j].tests[k];
+  var validateOptions = test.validateOptions || env.defaultOptions;
+  var res = env.validate(schema, test.data, validateOptions);
   it(test.description, function () {
-    if (test.valid)
-      expect(env.validate(schema, test.data)).to.be.equal(null);
-    else
-      expect(env.validate(schema, test.data)).not.to.be.equal(null);
+    if (test.valid) {
+      expect(res).to.be.equal(null);
+      if (test.hasOwnProperty('result'))
+        expect(test.data).to.eql(test.result);
+    } else {
+      expect(res).not.to.be.equal(null);
+    }
   });
 }
 


### PR DESCRIPTION
Current jjv's validate() does not update an object if OneOf or AnyOf is present in the root of the schema it was provided. With only test/test-suite.js and test/fixtures/oneOf.json patches applied, this is visible: npm test fails. The lib/jjv.js patch fixes this.