### PR TITLE
added test for default values in items

### DIFF
--- a/lib/jjv.js
+++ b/lib/jjv.js
@@ -356,6 +356,13 @@
       if (typeof schema.type === 'string') {
         if (options.useCoerce && env.coerceType.hasOwnProperty(schema.type))
           prop = object[name] = env.coerceType[schema.type](prop);
+        if (options.useDefault && schema.default){
+          if ( (prop === undefined || prop === null || prop === '') ||
+            (schema.type === 'array' && !prop.length && Array.isArray(prop)) ||
+            (schema.type === 'object' && JSON.stringify(prop) === JSON.stringify({}))) {
+            prop = object[name] = clone(schema.default);
+          }
+        }
         if (!env.fieldType[schema.type](prop))
           return {'type': schema.type};
       } else {
@@ -549,6 +556,8 @@
         for (p in schema.properties)
           if (schema.properties.hasOwnProperty(p) && !prop.hasOwnProperty(p) && schema.properties[p].hasOwnProperty('default'))
             prop[p] = clone(schema.properties[p]['default']);
+          else if (schema.properties[p] && schema.properties[p].items && !prop.hasOwnProperty(p) && schema.properties[p].items.hasOwnProperty('default'))
+            prop[p] = clone(schema.properties[p].items['default']);
       }
 
       if (options.removeAdditional && hasProp && schema.additionalProperties !== true && typeof schema.additionalProperties !== 'object') {


### PR DESCRIPTION
Currently `default` doesnt work when used in `items`, this PR adds support for default and adds a test for the interaction of `useDefault` with `useCoerce` and `items`

This populates `useDefault` early, right after `useCoerce` and populating `items` if they are empty. let me know what you think, or if there might be a better place to ensure that `items` and `useDefault` get checked in the right order.
